### PR TITLE
Add GitHub Actions E2E test actuation

### DIFF
--- a/.github/workflows/test_e2e_cf_pp.yaml
+++ b/.github/workflows/test_e2e_cf_pp.yaml
@@ -1,0 +1,105 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Test Cloud Functions E2E (per-project)
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  CI_PREFIX: 'spanner-as'
+
+jobs:
+  test:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        id: 'checkout'
+        uses: 'actions/checkout@v3'
+
+      - name: 'Construct project ID'
+        id: 'compute-test-uid'
+        run: |-
+          echo "PROJECT_ID=${CI_PREFIX}-${GITHUB_SHA::7}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}" >> ${GITHUB_ENV}
+
+      - name: 'Google auth'
+        id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          workload_identity_provider: '${{ secrets.WIF_PROVIDER }}'
+          service_account: '${{ secrets.WIF_SERVICE_ACCOUNT }}'
+          project_id: '${{ env.PROJECT_ID }}'
+
+      - name: 'Set up Cloud SDK'
+        id: 'gcloud-setup'
+        uses: 'google-github-actions/setup-gcloud@v1'
+        with:
+          project_id: '${{ env.PROJECT_ID }}'
+          install_components: 'beta'
+
+      - name: 'Create a project'
+        id: 'create-project'
+        run: |-
+          gcloud projects create ${PROJECT_ID} --folder ${{ secrets.CI_ENV_FOLDER_NUMBER }}
+
+      - name: 'Enable billing'
+        id: 'enable-billing'
+        run: |-
+          gcloud services enable cloudbilling.googleapis.com --project ${PROJECT_ID} && sleep 10
+
+      - name: 'Configure billing'
+        id: 'configure-billing'
+        run: |-
+          gcloud beta billing projects link ${PROJECT_ID} --billing-account=${{ secrets.CI_BILLING }}
+
+      - name: 'Enable all required APIs'
+        id: 'enable-apis'
+        run: |-
+          gcloud services enable --project ${PROJECT_ID} \
+             appengine.googleapis.com \
+             cloudbuild.googleapis.com \
+             cloudfunctions.googleapis.com \
+             cloudresourcemanager.googleapis.com \
+             cloudscheduler.googleapis.com \
+             firestore.googleapis.com \
+             iam.googleapis.com \
+             pubsub.googleapis.com \
+             spanner.googleapis.com
+
+      - name: 'Enable App Engine'
+        id: 'enable-app-engine'
+        run: |-
+          gcloud app create --region=us-central --project ${PROJECT_ID}
+
+      - name: 'Enable Firestore'
+        id: 'enable-firestore'
+        run: |-
+          gcloud firestore databases update --type=firestore-native --project ${PROJECT_ID}
+
+      - name: 'Run the E2E test'
+        id: 'run-e2e-test'
+        run: |-
+          cd terraform/cloud-functions/per-project/test && make test-e2e
+
+      - name: 'Delete project'
+        id: 'delete-project'
+        if: always()
+        run: |-
+          gcloud projects delete ${PROJECT_ID} --quiet

--- a/.github/workflows/test_project_cleanup.yaml
+++ b/.github/workflows/test_project_cleanup.yaml
@@ -1,0 +1,53 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Clean up test projects
+
+on:
+  schedule:
+    # Run every three hours
+    - cron: '0 */3 * * *'
+
+jobs:
+  test:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        id: 'checkout'
+        uses: 'actions/checkout@v3'
+
+      - name: 'Google auth'
+        id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          workload_identity_provider: '${{ secrets.WIF_PROVIDER }}'
+          service_account: '${{ secrets.WIF_SERVICE_ACCOUNT }}'
+
+      - name: 'Set up Cloud SDK'
+        id: 'gcloud-setup'
+        uses: 'google-github-actions/setup-gcloud@v1'
+        with:
+          install_components: 'alpha'
+
+      - name: 'Delete all CI projects over an hour old'
+        id: 'delete-projects'
+        run: |
+          for PROJECT_ID in $(gcloud alpha projects list --folder=${{ secrets.CI_ENV_FOLDER_NUMBER }} --format="value(projectId)" --filter="createTime<-P1H")
+          do
+            gcloud projects delete ${PROJECT_ID} --quiet
+          done


### PR DESCRIPTION
This PR adds GitHub Actions workflows to:

- Run the end-to-end tests for Cloud Functions (per-project topology) on merge to master, and
- Periodically clean up any resources that may not have been deleted by the main workflow